### PR TITLE
Fixed admin volunteer interests filter not working

### DIFF
--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -24,7 +24,7 @@ ActiveAdmin.register User, as: 'Volunteer' do
     filter :username
     filter :email
     filter :created_at
-    filter :interests
+    filter :interests, collection: proc { Interest.all }
     
     form do |f| 
         f.inputs do


### PR DESCRIPTION
Previously, the filter worked by getting the `interests` column from the `users` table, but this is not where the list of possible interests is actually populated. Instead, it not uses a proc to get all the items from the `interests` table.